### PR TITLE
Use readFileSync instead of readFile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freave/make-pot",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Scans files in a given directory for translatable strings. Generates a POT file.",
   "main": "dist/src/index.js",
   "files": [

--- a/src/helpers/getMatches.ts
+++ b/src/helpers/getMatches.ts
@@ -1,22 +1,13 @@
-import { readFile } from "node:fs/promises";
+import { readFileSync } from "node:fs";
 import { lineEnding, matchGroups } from "../consts";
 import { matchResults } from "../types";
 
 export const getMatches = async (files: string[]): Promise<matchResults[] | []> => {
-  let contentPromises: any[] = [];
+  let contents: any[] = [];
 
   for (const file of files) {
-    contentPromises.push({ body: await readFile(file, 'utf8'), filename: file });
+    contents.push({ body: readFileSync(file, 'utf8'), filename: file });
   }
-
-  const contents = await Promise.all(
-    contentPromises.map(async (contentPromise) => {
-        return {
-          ...contentPromise,
-          body: await contentPromise.body
-        };
-      }
-    ));
 
   let formattedMatches: matchResults[] = [];
 

--- a/src/helpers/getMatches.ts
+++ b/src/helpers/getMatches.ts
@@ -1,4 +1,4 @@
-import { readFile } from "node:fs/promises";
+import { readFileSync } from "node:fs";
 import { lineEnding, matchGroups } from "../consts";
 import { matchResults } from "../types";
 
@@ -6,7 +6,7 @@ export const getMatches = async (files: string[]): Promise<matchResults[] | []> 
   let contentPromises: any[] = [];
 
   for (const file of files) {
-    contentPromises.push({ body: readFile(file, 'utf8'), filename: file });
+    contentPromises.push({ body: readFileSync(file, 'utf8'), filename: file });
   }
 
   const contents = await Promise.all(

--- a/src/helpers/getMatches.ts
+++ b/src/helpers/getMatches.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { lineEnding, matchGroups } from "../consts";
 import { matchResults } from "../types";
 
@@ -6,7 +6,7 @@ export const getMatches = async (files: string[]): Promise<matchResults[] | []> 
   let contentPromises: any[] = [];
 
   for (const file of files) {
-    contentPromises.push({ body: readFileSync(file, 'utf8'), filename: file });
+    contentPromises.push({ body: await readFile(file, 'utf8'), filename: file });
   }
 
   const contents = await Promise.all(


### PR DESCRIPTION
This pull request prevents opening all files as mentioned here: [!36](https://github.com/freave/make-pot/issues/36)
Instead it reads the files in a synchronous way.